### PR TITLE
add slider increment amount to address volume bug

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -24,15 +24,25 @@ async function sendCommandToTab(command, tab) {
       if (e.tagName.toLowerCase() === 'button') animate(e);
     }
 
-    function usingSlider(selector, goUp) {
+    function usingSlider(selector, goUp, increment = null) {
       const slider = document.querySelector(selector);
-      const value = parseInt(goUp ? slider.max : slider.min);
+      let value;
+      if (increment === null) {
+        value = parseInt(goUp ? slider.max : slider.min);
+      } else {
+        const currentValue = parseInt(slider.value);
+        const maxValue = parseInt(slider.max);
+        const minValue = parseInt(slider.min);
+        value = currentValue + (goUp ? increment : -increment) * (maxValue - minValue);
+        value = Math.max(minValue, Math.min(maxValue, value));
+      }
       VALUE_SET.call(slider, value);
       slider.dispatchEvent(new Event('change', { value, bubbles: true }));
     }
 
     function usingVolumeSlider(command) {
-      usingSlider('[data-testid*=volume] input[type=range]', command == 'volume-up');
+      const VOLUME_INCREMENT = 0.1; // 10% increment/decrement
+      usingSlider('[data-testid*=volume] input[type=range]', command == 'volume-up', VOLUME_INCREMENT);
     }
 
     function usingSeekSlider(command) {

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
     "name": "__MSG_application_title__",
     "description": "__MSG_application_description__",
-    "version": "1.4.1",
+    "version": "1.4.2",
     "default_locale": "en",
     "manifest_version": 3,
     "icons": {


### PR DESCRIPTION
I attempted to address the [Volume control goes to 100% or 0%](https://github.com/zopieux/spotify-hotkeys/issues/19) bug here. I'm honestly stumped by how this function ever worked before bc it seems to want to set to either 100% or 0% and that code seems to have been in place for around 2 years. I cannot figure out how/why it worked in 10% increments before.

Changes:
- add an optional "increment value" to the useSlider function that allows you to set how much it should increment/decrement whenever the function is called
- the volume slider function sends an increment value of 10%
- if you don't provide an increment value (such as with seekbar), the slider function continues to set to max or min as it did before

Note: I couldn't actually load this into Chrome to properly test it because of how the ZIP was structured. I don't usually work on Chrome extensions so I wasn't sure how do address the issue without changing a bunch more stuff. When I changed things locally (like where the manifest was, and where it looks for icon images) it worked, but I'm not including those changes here.